### PR TITLE
list channels & list pico children

### DIFF
--- a/rulesets/wrangler_dev.krl
+++ b/rulesets/wrangler_dev.krl
@@ -265,15 +265,6 @@ ruleset v1_wrangler {
   children = function() {
     self = meta:eci().klog("meta eci for list_children:  ");
     children = pci:list_children(self).defaultsTo("error", standardError("pci children list failed"));
-   /* my_children = ent:my_children.filter(function(child)
-                                          {
-                                            this_eci = child{"eci"};
-				                                    children.filter(function(rec)
-                                              {
-				                                        rec[0] eq this_eci
-                                              })
-					                                   .length() > 0
-                                          });*/
     ent_my_children = ent:my_children;
     my_child_list = children.map(function(tuple)
                                           {
@@ -289,7 +280,6 @@ ruleset v1_wrangler {
                                                               }
                                             return.klog("second filter: ")
                                           }).klog("map : ");
-    // join list of children
 
     {
       'status' : (children neq "error"),

--- a/rulesets/wrangler_dev.krl
+++ b/rulesets/wrangler_dev.krl
@@ -160,8 +160,19 @@ ruleset v1_wrangler {
     channel = function(id,collection,filtered) { 
       eci = meta:eci();
       results = pci:list_eci(eci).defaultsTo({},standardError("undefined")); // list of ECIs assigned to userid
-      channels = results{'channels'}.defaultsTo("error",standardError("undefined")); // list of channels if list_eci request was valid
-      
+      chans = results{'channels'}.defaultsTo("error",standardError("undefined")); // list of channels if list_eci request was valid
+      channels = chans.map(function(channel){ // reconstruct each channel to have eci not cid
+                                            chan = channel.put(["eci"],channel{"cid"}); 
+                                            chann = chan.delete(["cid"]);
+                                            chann // return reconstructed channel 
+                                           /* {
+                                              "last_active":channel{"last_active"},
+                                              "policy":channel{"policy"},
+                                              "name":channel{"name"},
+                                              "type":channel{"type"},
+                                              "eci":channel{"cid"},
+                                              "attributes":channel{"attributes"}
+                                              } */});
       single_channel = function(value,chans){
          // if value is a number with ((([A-Z]|\d)*-)+([A-Z]|\d)*) attribute is cid.
         attribute = (value.match(re/(^(([A-Z]|\d)+-)+([A-Z]|\d)+$)/)) => 

--- a/rulesets/wrangler_dev.krl
+++ b/rulesets/wrangler_dev.krl
@@ -293,7 +293,7 @@ ruleset v1_wrangler {
 
     {
       'status' : (children neq "error"),
-      'children' : my_children
+      'children' : my_child_list
     }
   }
   parent = function() {

--- a/rulesets/wrangler_dev.krl
+++ b/rulesets/wrangler_dev.krl
@@ -282,7 +282,7 @@ ruleset v1_wrangler {
                                               {
                                                 ent_child{"eci"} eq this_eci
                                               }).klog("first filter: ");
-                                            return = return1.length() > 0 => return[0] | // if child with name return the name structure  
+                                            return = return1.length() > 0 => return1[0] | // if child with name return the name structure  
                                                               {  // if child with no name return with unknown name structure
                                                                 "name": "unknown",
                                                                 "eci": this_eci

--- a/rulesets/wrangler_dev.krl
+++ b/rulesets/wrangler_dev.krl
@@ -278,7 +278,7 @@ ruleset v1_wrangler {
     my_child_list = children.map(function(tuple)
                                           {
                                             this_eci = tuple[0];
-                                            ent_my_children.filter(function(ent_child)
+                                            return = ent_my_children.filter(function(ent_child)
                                               {
                                                 ent_child{"eci"} eq this_eci
                                               })
@@ -287,6 +287,7 @@ ruleset v1_wrangler {
                                                                 "name": "unknown",
                                                                 "eci": this_eci
                                                               }
+                                            return
                                           });
     // join list of children
 

--- a/rulesets/wrangler_dev.krl
+++ b/rulesets/wrangler_dev.krl
@@ -282,7 +282,7 @@ ruleset v1_wrangler {
                                               {
                                                 ent_child{"eci"} eq this_eci
                                               }).klog("first filter: ")
-                                             .length() > 0 => ent_child | // if child with name return the name structure  
+                                             .length() > 0 => ent_child[0] | // if child with name return the name structure  
                                                               {  // if child with no name return with unknown name structure
                                                                 "name": "unknown",
                                                                 "eci": this_eci

--- a/rulesets/wrangler_dev.krl
+++ b/rulesets/wrangler_dev.krl
@@ -288,7 +288,7 @@ ruleset v1_wrangler {
                                                                 "eci": this_eci
                                                               }
                                             return.klog("second filter: ")
-                                          });
+                                          }).klog("map : ");
     // join list of children
 
     {

--- a/rulesets/wrangler_dev.krl
+++ b/rulesets/wrangler_dev.krl
@@ -162,17 +162,17 @@ ruleset v1_wrangler {
       results = pci:list_eci(eci).defaultsTo({},standardError("undefined")); // list of ECIs assigned to userid
       chans = results{'channels'}.defaultsTo("error",standardError("undefined")); // list of channels if list_eci request was valid
       channels = chans.map(function(channel){ // reconstruct each channel to have eci not cid
-                                            chan = channel.put(["eci"],channel{"cid"}); 
-                                            chann = chan.delete(["cid"]);
-                                            chann // return reconstructed channel 
-                                           /* {
+                                          //  chan = channel.put(["eci"],channel{"cid"}); 
+                                          //  chann = chan.delete(["cid"]);
+                                          //  chann // return reconstructed channel 
+                                            {
                                               "last_active":channel{"last_active"},
                                               "policy":channel{"policy"},
                                               "name":channel{"name"},
                                               "type":channel{"type"},
                                               "eci":channel{"cid"},
                                               "attributes":channel{"attributes"}
-                                              } */});
+                                              } });
       single_channel = function(value,chans){
          // if value is a number with ((([A-Z]|\d)*-)+([A-Z]|\d)*) attribute is cid.
         attribute = (value.match(re/(^(([A-Z]|\d)+-)+([A-Z]|\d)+$)/)) => 

--- a/rulesets/wrangler_dev.krl
+++ b/rulesets/wrangler_dev.krl
@@ -281,13 +281,13 @@ ruleset v1_wrangler {
                                             return = ent_my_children.filter(function(ent_child)
                                               {
                                                 ent_child{"eci"} eq this_eci
-                                              })
+                                              }).klog("first filter: ")
                                              .length() > 0 => ent_child | // if child with name return the name structure  
                                                               {  // if child with no name return with unknown name structure
                                                                 "name": "unknown",
                                                                 "eci": this_eci
                                                               }
-                                            return
+                                            return.klog("second filter: ")
                                           });
     // join list of children
 

--- a/rulesets/wrangler_dev.krl
+++ b/rulesets/wrangler_dev.krl
@@ -265,14 +265,30 @@ ruleset v1_wrangler {
   children = function() {
     self = meta:eci().klog("meta eci for list_children:  ");
     children = pci:list_children(self).defaultsTo("error", standardError("pci children list failed"));
-
-    my_children = ent:my_children.filter(function(child){
-                                 this_eci = child{"eci"};
-				 children.filter(function(rec){
-				                   rec[0] eq this_eci
-                                                 })
-					 .length() > 0
-                               })
+   /* my_children = ent:my_children.filter(function(child)
+                                          {
+                                            this_eci = child{"eci"};
+				                                    children.filter(function(rec)
+                                              {
+				                                        rec[0] eq this_eci
+                                              })
+					                                   .length() > 0
+                                          });*/
+    ent_my_children = ent:my_children;
+    my_child_list = children.map(function(tuple)
+                                          {
+                                            this_eci = tuple[0];
+                                            ent_my_children.filter(function(ent_child)
+                                              {
+                                                ent_child{"eci"} eq this_eci
+                                              })
+                                             .length() > 0 => ent_child | // if child with name return the name structure  
+                                                              {  // if child with no name return with unknown name structure
+                                                                "name": "unknown",
+                                                                "eci": this_eci
+                                                              }
+                                          });
+    // join list of children
 
     {
       'status' : (children neq "error"),

--- a/rulesets/wrangler_dev.krl
+++ b/rulesets/wrangler_dev.krl
@@ -278,11 +278,11 @@ ruleset v1_wrangler {
     my_child_list = children.map(function(tuple)
                                           {
                                             this_eci = tuple[0];
-                                            return = ent_my_children.filter(function(ent_child)
+                                            return1 = ent_my_children.filter(function(ent_child)
                                               {
                                                 ent_child{"eci"} eq this_eci
-                                              }).klog("first filter: ")
-                                             .length() > 0 => ent_child[0] | // if child with name return the name structure  
+                                              }).klog("first filter: ");
+                                            return = return1.length() > 0 => return[0] | // if child with name return the name structure  
                                                               {  // if child with no name return with unknown name structure
                                                                 "name": "unknown",
                                                                 "eci": this_eci


### PR DESCRIPTION
displays channels with eci instead of cid. displays all children of a pico whether the pico has a name or not. 
