### PR TITLE
corrects pci:list_children & pci:list_parent fail when empty bug.

### DIFF
--- a/rulesets/wrangler.krl
+++ b/rulesets/wrangler.krl
@@ -239,7 +239,7 @@ ruleset v1_wrangler {
                                           ;
     {
       'status' : (children neq "error"),
-      'children' : my_child_list
+      'children' : (children neq "error") => my_child_list | []
     }.klog("children :");
   }
   parent = function() {
@@ -247,7 +247,7 @@ ruleset v1_wrangler {
     parent = pci:list_parent(self).defaultsTo("error", standardError("pci parent retrieval failed"));
     {
       'status' : (parent neq "error"),
-      'parent' : parent
+      'parent' : (parent neq "error") => parent | []
     }.klog("parent :");
   }
 


### PR DESCRIPTION
pci functions appear to fail when return object is empty or null. while
this is investigated wrangler will return an empty list on select pci
error results.