### PR TITLE
use event attribute name space

### DIFF
--- a/rulesets/wrangler.krl
+++ b/rulesets/wrangler.krl
@@ -1560,7 +1560,7 @@ ruleset v1_wrangler {
           // should this go into the hash above?
       unique_name = (status eq "inbound") => 
             //randomName(pending_subscriptions{'name_space'}) 
-            name_space + ":" + event:attr("name")
+            event:attr("name_space") + ":" + event:attr("name")
             |
             channel_name;
       options = {


### PR DESCRIPTION
Creates a channel name from event attributes name_space and name.
this corrects a bug where name_space, undefined variable, was used.