### PR TITLE
devtools website needs error string

### DIFF
--- a/rulesets/wrangler.krl
+++ b/rulesets/wrangler.krl
@@ -247,7 +247,7 @@ ruleset v1_wrangler {
     parent = pci:list_parent(self).defaultsTo("error", standardError("pci parent retrieval failed"));
     {
       'status' : (parent neq "error"),
-      'parent' : (parent neq "error") => parent | []
+      'parent' :  parent 
     }.klog("parent :");
   }
 


### PR DESCRIPTION
devtools website uses the error string in its logic to display
registered rulesets and parent button. correcting this was actually a
bug. we need to go back to error instead of [] for the moment.